### PR TITLE
fix: InvalidArgumentExcpetion due to empty string

### DIFF
--- a/advanced_search_tips.module
+++ b/advanced_search_tips.module
@@ -175,7 +175,7 @@ function advanced_search_tips_form_alter(&$form, \Drupal\Core\Form\FormStateInte
                 <div class="modal-content">
                     <div class="modal-header">
                         <h3 class="modal-title" id="exampleModalLongTitle">
-                          ' . t($config->get("tips_title")) .'
+                          ' . t($config->get("tips_title") ?: 'Advanced Search Tips') .'
                         </h3>
                         <p>
                             <button class="close" aria-label="Close" data-dismiss="modal" type="button"><span aria-hidden="true">×</span></button>


### PR DESCRIPTION
# Description
This PR solves the `InvalidArgumentException` warning in the log messages which is caused due to an empty string being passed for translation. Additionally, all the Advanced Search Blocks fail to load. The following warning is logged:
```
User warning: InvalidArgumentException: $string ("") must be a string. in /var/www/drupal/web/core/lib/Drupal/Core/StringTranslation/TranslatableMarkup.php:132 Stack trace: #0 /var/www/drupal/web/core/includes/bootstrap.inc(104): Drupal\Core\StringTranslation\TranslatableMarkup->__construct() #1 /var/www/drupal/web/modules/contrib/advanced_search_tips/advanced_search_tips.module(178): t() #2 /var/www/drupal/web/core/lib/Drupal/Core/Extension/ModuleHandler.php(552): advanced_search_tips_form_alter() #3 /var/www/drupal/web/core/lib/Drupal/Core/Form/FormBuilder.php(839): Drupal\Core\Extension\ModuleHandler->alter() #4 /var/www/drupal/web/core/lib/Drupal/Core/Form/FormBuilder.php(285): Drupal\Core\Form\FormBuilder->prepareForm() #5 /var/www/drupal/web/core/lib/Drupal/Core/Form/FormBuilder.php(224): Drupal\Core\Form\FormBuilder->buildForm() #6 /var/www/drupal/web/modules/contrib/advanced_search/src/Plugin/Block/AdvancedSearchBlock.php(374): Drupal\Core\Form\FormBuilder->getForm() #7 /var/www/drupal/web/core/modules/block/src/BlockViewBuilder.php(171): Drupal\advanced_search\Plugin\Block\AdvancedSearchBlock->build() #8 [internal function]: Drupal\block\BlockViewBuilder::preRender() #9 /var/www/drupal/web/core/lib/Drupal/Core/Security/DoTrustedCallbackTrait.php(113): call_user_func_array() #10 /var/www/drupal/web/core/lib/Drupal/Core/Render/Renderer.php(886): Drupal\Core\Render\Renderer->doTrustedCallback() #11 /var/www/drupal/web/core/lib/Drupal/Core/Render/Renderer.php(431): Drupal\Core\Render\Renderer->doCallback() #12 /var/www/drupal/web/core/lib/Drupal/Core/Render/Renderer.php(248): Drupal\Core\Render\Renderer->doRender() #13 /var/www/drupal/web/core/lib/Drupal/Core/Render/Renderer.php(165): Drupal\Core\Render\Renderer->render() #14 /var/www/drupal/web/core/lib/Drupal/Core/Render/Renderer.php(637): Drupal\Core\Render\Renderer->Drupal\Core\Render\{closure}() #15 /var/www/drupal/web/core/lib/Drupal/Core/Render/Renderer.php(164): Drupal\Core\Render\Renderer->executeInRenderContext() #16 /var/www/drupal/web/core/lib/Drupal/Core/Render/Renderer.php(191): Drupal\Core\Render\Renderer->renderInIsolation() #17 /var/www/drupal/web/core/lib/Drupal/Core/Render/Renderer.php(228): Drupal\Core\Render\Renderer->doRenderPlaceholder() #18 /var/www/drupal/web/core/modules/big_pipe/src/Render/BigPipe.php(697): Drupal\Core\Render\Renderer->renderPlaceholder() #19 /var/www/drupal/web/core/modules/big_pipe/src/Render/BigPipe.php(524): Drupal\big_pipe\Render\BigPipe->renderPlaceholder() #20 [internal function]: Drupal\big_pipe\Render\BigPipe->Drupal\big_pipe\Render\{closure}() #21 /var/www/drupal/web/core/modules/big_pipe/src/Render/BigPipe.php(531): Fiber->start() #22 /var/www/drupal/web/core/modules/big_pipe/src/Render/BigPipe.php(283): Drupal\big_pipe\Render\BigPipe->sendPlaceholders() #23 /var/www/drupal/web/core/modules/big_pipe/src/Render/BigPipeResponse.php(113): Drupal\big_pipe\Render\BigPipe->sendContent() #24 /var/www/drupal/vendor/symfony/http-foundation/Response.php(423): Drupal\big_pipe\Render\BigPipeResponse->sendContent() #25 /var/www/drupal/web/index.php(20): Symfony\Component\HttpFoundation\Response->send() #26 {main} in Drupal\big_pipe\Render\BigPipe->sendPlaceholders() (line 606 of /var/www/drupal/web/core/modules/big_pipe/src/Render/BigPipe.php)
#0 /var/www/drupal/web/core/includes/bootstrap.inc(166): _drupal_error_handler_real()
#1 [internal function]: _drupal_error_handler()
#2 /var/www/drupal/web/core/modules/big_pipe/src/Render/BigPipe.php(606): trigger_error()
#3 /var/www/drupal/web/core/modules/big_pipe/src/Render/BigPipe.php(283): Drupal\big_pipe\Render\BigPipe->sendPlaceholders()
#4 /var/www/drupal/web/core/modules/big_pipe/src/Render/BigPipeResponse.php(113): Drupal\big_pipe\Render\BigPipe->sendContent()
#5 /var/www/drupal/vendor/symfony/http-foundation/Response.php(423): Drupal\big_pipe\Render\BigPipeResponse->sendContent()
#6 /var/www/drupal/web/index.php(20): Symfony\Component\HttpFoundation\Response->send()
#7 {main}
.
```

# Changes
This PR makes a small improvement to the `advanced_search_tips_form_alter` function to ensure a default title is shown if a custom title is not set in the configuration.