### PR TITLE
refactor/phpcs-ignore-comments

### DIFF
--- a/advanced_search_tips.module
+++ b/advanced_search_tips.module
@@ -82,12 +82,11 @@ function advanced_search_tips_form_alter(&$form, FormStateInterface $form_state,
       '#type' => 'textfield',
       '#title' => t('Title:'),
       '#default_value' => ($config->get("tips_title") !== NULL) ? $config->get("tips_title") : "Advanced Search Tips",
-      // phpcs:ignore -- #description values usually have to run through t() for translation
-      '#description' => '<p><strong>Note: </strong></p><ul> <li>For multilingual, switch over <strong>Source </strong> mode, then
+      '#description' => t('<p><strong>Note: </strong></p><ul> <li>For multilingual, switch over <strong>Source </strong> mode, then
         <ul>
         <li>Tag multilingal content with associate language code ie. English => en, Tamil => ta, or French => fr </li>
         <li>If there are complicated hiarachy of html components, only tagging the parent tag instead all of its chidlren </li>
-        </ul></li></ul>',
+        </ul></li></ul>'),
     ];
     $form['advanced_search_tips']['tips_html'] = [
       '#type' => 'text_format',
@@ -171,7 +170,7 @@ function advanced_search_tips_form_alter(&$form, FormStateInterface $form_state,
       $search_tip = $config->get("tips_html");
     }
 
-    // phpcs:disable
+    // phpcs:disable -- Drupal.Semantics.FunctionT.Concat
     $form["advanced_search_tips_modal-popup"] = [
       '#type' => 'markup',
       "#markup" => new TranslatableMarkup('
@@ -180,7 +179,7 @@ function advanced_search_tips_form_alter(&$form, FormStateInterface $form_state,
                 <div class="modal-content">
                     <div class="modal-header">
                         <h3 class="modal-title" id="exampleModalLongTitle">
-                          ' . t($config->get("tips_title") ?: 'Advanced Search Tips') . '
+                          ' . t('@title', ['@title' => $config->get("tips_title") ?: 'Advanced Search Tips']) . '
                         </h3>
                         <p>
                             <button class="close" aria-label="Close" data-dismiss="modal" type="button"><span aria-hidden="true">×</span></button>
@@ -193,7 +192,6 @@ function advanced_search_tips_form_alter(&$form, FormStateInterface $form_state,
             </div>
         </div>'),
     ];
-    // phpcs:enable
   }
 }
 

--- a/advanced_search_tips.services.yml
+++ b/advanced_search_tips.services.yml
@@ -1,6 +1,6 @@
 services:
   advanced_search.request_subscriber:
     class: Drupal\advanced_search_tips\EventSubscriber\RequestSubscriber
-    arguments: ['@current_route_match']
+    arguments: ['@current_route_match', '@config.factory']
     tags:
       - { name: event_subscriber }

--- a/src/EventSubscriber/RequestSubscriber.php
+++ b/src/EventSubscriber/RequestSubscriber.php
@@ -7,20 +7,33 @@ use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
 
 /**
  * The RequestSubscriber class.
  */
 class RequestSubscriber implements EventSubscriberInterface {
 
-  // phpcs:ignore -- Missing member variable doc comment
+  /**
+   * The route match service.
+   *
+   * @var \Drupal\Core\Routing\RouteMatchInterface
+   */
   protected $routeMatch;
+
+  /**
+   * The config factory service.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
 
   /**
    * Constructs a new RequestSubscriber object.
    */
-  public function __construct(RouteMatchInterface $route_match) {
+  public function __construct(RouteMatchInterface $route_match, ConfigFactoryInterface $config_factory) {
     $this->routeMatch = $route_match;
+    $this->configFactory = $config_factory;
   }
 
   /**
@@ -78,8 +91,7 @@ class RequestSubscriber implements EventSubscriberInterface {
    * Handles the request event.
    */
   public function onRequest(RequestEvent $event) {
-    // phpcs:ignore -- \Drupal calls should be avoided in classes, use dependency injection instead
-    $config = \Drupal::config('advanced_search.settings');
+    $config = $this->configFactory->get('advanced_search.settings');
     if (isset($config) && $config->get("search_request_validation") === 1) {
       $request = $event->getRequest();
       $referer = $request->headers->get('referer');


### PR DESCRIPTION
# Description
This PR refactors the codebase by implementing dependency injection for missing services, adding translation to important form elements, and utilizing string placeholders.

# Changes
- `advanced_search_tips.module` - Added translatability to description of the form elements, and change to using string placeholders.
- `advanced_search_tips.services.yml` - Add config factory as a argument which is used in `src/EventSubscriber/RequestSubscriber.php`.
- `src/EventSubscriber/RequestSubscriber.php` - Update to using dependency injection for the config factory.